### PR TITLE
add tailwind css template to breadcrumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The possible values are:
 - `breadcrumbs::foundation6` – [Foundation 6](https://get.foundation/sites/docs/breadcrumbs.html)
 - `breadcrumbs::materialize` – [Materialize](https://materializecss.com/breadcrumbs.html)
 - `breadcrumbs::uikit` – [UIkit](https://getuikit.com/docs/breadcrumb)
+- `breadcrumbs::tailwind` – [Tailwind CSS](https://tailwindcss.com/)
 - `breadcrumbs::json-ld` – [JSON-LD Structured Data](https://developers.google.com/search/docs/data-types/breadcrumbs)
 (&lt;script&gt; tag, no visible output)
 - The path to a custom view: e.g. `partials.breadcrumbs`

--- a/config/breadcrumbs.php
+++ b/config/breadcrumbs.php
@@ -17,6 +17,7 @@ return [
     | - 'breadcrumbs::foundation6' - Foundation 6
     | - 'breadcrumbs::materialize' - Materialize
     | - 'breadcrumbs::uikit'       - UIkit
+    | - 'breadcrumbs::tailwind'       - Tailwind CSS
     | - 'breadcrumbs::json-ld'     - JSON-LD Structured Data
     |
     | Or a custom view, e.g. '_partials/breadcrumbs'.

--- a/resources/views/tailwind.blade.php
+++ b/resources/views/tailwind.blade.php
@@ -1,0 +1,18 @@
+@if (count($breadcrumbs))
+    <nav class="container-fluid px-1">
+        <ol class="list-reset py-4 pl-4 rounded flex bg-gray-300 text-gray-800">
+            @foreach ($breadcrumbs as $breadcrumb)
+                @if ($breadcrumb->url && !$loop->last)
+                    <li class="px-2"><a href="{{ $breadcrumb->url }}" class="no-underline text-blue-600">{{ $breadcrumb->title }}</a></li>
+                @else
+                    <li class="px-2">{{ $breadcrumb->title }}</li>
+                @endif
+                @if(!$loop->last)
+                    <li class="text-gray-500">/</li>
+                @endif
+            @endforeach
+        </ol>
+    </nav>
+@endif
+
+


### PR DESCRIPTION
I tried to add a beautiful breadcrumb with Tailwind CSS .

The result :
![Screenshot 2020-11-04 131158](https://user-images.githubusercontent.com/29504334/98095084-5afb8b00-1e9f-11eb-8c7f-3ceeeb47b522.png)
