### PR TITLE
Fix template/snapshot tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,6 @@
 
 /scripts/ export-ignore
 /tests/ export-ignore
+
+# Ensure the correct line endings are used in tests on Windows
+* text=auto eol=lf

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: tests
 on:
   # Run action on every push
   push:
-    
+
   # Run action at midnight to test against any updated dependencies
   schedule:
   - cron: '0 0 * * *'
@@ -15,17 +15,17 @@ jobs:
                 php: [7.4, 7.3, 7.2]
                 laravel: [8.*, 7.*, 6.*]
                 os: [ubuntu-latest, windows-latest]
-                
+
                 # Unsupported combinations
                 exclude:
                 - laravel: 8.*
                   php: 7.2
-            
+
             # Continue running through matrix even if one combination fails
             fail-fast: false
 
         runs-on: ${{ matrix.os }}
-        
+
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }}
 
         steps:
@@ -42,14 +42,12 @@ jobs:
               run: |
                     # Install Laravel version per matrix
                     composer require --dev "laravel/framework:${{ matrix.laravel }}" --no-interaction
-                
+
                     composer install --no-interaction
 
             - name: Execute PHPUnit tests
-              # Update snapshots each time to deal with platform differences
-              # @see https://github.com/spatie/phpunit-snapshot-assertions/issues/105
-              run: vendor/bin/phpunit -d --update-snapshots --coverage-clover build/logs/clover.xml
-              
+              run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+
             - name: Report coverage to Codecov
               uses: codecov/codecov-action@v1
               with:

--- a/tests/__snapshots__/TemplatesTest__testView with data set tailwind__1.xml
+++ b/tests/__snapshots__/TemplatesTest__testView with data set tailwind__1.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<nav class="container mx-auto">
+  <ol class="p-4 rounded flex flex-wrap bg-gray-300 text-sm text-gray-800">
+    <li>
+      <a href="http://localhost" class="text-blue-600 hover:text-blue-900 hover:underline focus:text-blue-900 focus:underline">
+                            Home
+                        </a>
+    </li>
+    <li class="text-gray-500 px-2">
+                        /
+                    </li>
+    <li>
+                        Blog
+                    </li>
+    <li class="text-gray-500 px-2">
+                        /
+                    </li>
+    <li>
+                        Sample Category
+                    </li>
+  </ol>
+</nav>


### PR DESCRIPTION
- Remove `-d --update-snapshots` (it effectively disables all snapshot tests! e.g. [this test](https://github.com/alberon/laravel-breadcrumbs/actions/runs/371931807) should have failed)
- Normalise all line endings to LF instead
- Add the missing snapshot for the new Tailwind view