### PR TITLE
fix: pass all signature parameters to breadcrumb function

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -250,10 +250,9 @@ class Manager
         }
 
         // Get the current route parameters
-        $signatureParameters = array_slice($route->signatureParameters(), 1);
-        $params = array_values(array_map(function ($parameter) use ($route) {
-            return $route->parameter($parameter->name);
-        }, $signatureParameters));
+        $params = array_values(array_map(function ($parameterName) use ($route) {
+            return $route->parameter($parameterName);
+        }, $route->parameterNames()));
 
         return [$name, $params];
     }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -250,7 +250,12 @@ class Manager
         }
 
         // Get the current route parameters
-        $params = array_values($route->parameters());
+        $params = array_values(array_map(function ($parameter) use ($route) {
+            return $route->parameter($parameter->name);
+        }, $route->signatureParameters()));
+
+        // Remove $request parameter
+        array_shift($params);
 
         return [$name, $params];
     }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -250,12 +250,10 @@ class Manager
         }
 
         // Get the current route parameters
+        $signatureParameters = array_slice($route->signatureParameters(), 1);
         $params = array_values(array_map(function ($parameter) use ($route) {
             return $route->parameter($parameter->name);
-        }, $route->signatureParameters()));
-
-        // Remove $request parameter
-        array_shift($params);
+        }, $signatureParameters));
 
         return [$name, $params];
     }


### PR DESCRIPTION
This is a special case but if you have an optional path parameter that is empty and inject another parameter on the fly via a middleware into the request, then the optional parameter is omitted. This PR makes sure that really all the signature parameters are passed on.