### PR TITLE
Add possibility to override existing callback for route name

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -53,12 +53,13 @@ class Manager
      * @param string $name The name of the page.
      * @param callable $callback The callback, which should accept a Generator instance as the first parameter and may
      *                           accept additional parameters.
+     * @param bool $override Overrides an existing callback for the $name if set to true and one already exists.
      * @return void
      * @throws \Diglactic\Breadcrumbs\Exceptions\DuplicateBreadcrumbException If the given name has already been used.
      */
-    public function for(string $name, callable $callback): void
+    public function for(string $name, callable $callback, bool $override = false): void
     {
-        if (isset($this->callbacks[$name])) {
+        if (isset($this->callbacks[$name]) && !$override) {
             throw new DuplicateBreadcrumbException($name);
         }
 


### PR DESCRIPTION
### What I want to do
I'd like to override a Breadcrumb definition that had already been set. When working with custom packages in your project, we'd like to predefine Breadcrumbs for routes, a single package provides and include the definition in the project. Sometimes, we need to override this defintion to reflect the projects needs more. 

### Current behaviour
When adding another definition for the same route, the [Diglactic\Breadcrumbs\Manager currently throws a DuplicateBreadcrumbException](https://github.com/diglactic/laravel-breadcrumbs/blob/b2c594e56fd15ef3112436e2067dca13131dd990/src/Manager.php#L62)

### Possible workarounds 
We could work around this, by only adding the packages Breadcrumb definitions if nothing changed or implement a custom Manager to override the for Method. I think, this issue might be of interest for other users, too. So I'd like to propose two possible changes:

### Proposed changes 

**Alternative 1: add an override bool to the method**

The for method in Manager could be changed by having a third optional parameter "override" which defaults to false. If override is true, the current existing callback (if any) would be overridden. If it exist and override is false, the exception will be thrown.

**Alternative 2: add a method to remove the existing defintion**

A new method will check if the $name already has a definition in the callbacks array. If not, a new RouteNotDefinedException will be thrown. Since the manager already has a exists method, this check should be done by the programmer and not the package. 

## Suggested change

Since overriding an already defined route is something, that will be done while knowing what the dev is doing, it might be better to go with alternative 1. Please see the attached pull request which does exactly that. 