### PR TITLE
Laravel 10 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ jobs:
   phpunit:
     strategy:
       matrix:
-        php: [ 8.1, 8.0, 7.4, 7.3, 7.2 ]
-        laravel: [ 10.*, 9.*, 8.*, 7.*, 6.* ]
+        php: [ 8.1, 8.0, 7.4, 7.3 ]
+        laravel: [ 10.*, 9.*, 8.* ]
         os: [ ubuntu-latest, windows-latest ]
 
         # Unsupported combinations
@@ -37,16 +37,6 @@ jobs:
 
           - laravel: 8.*
             php: 7.2
-
-          - laravel: 7.*
-            php: 8.1
-          - laravel: 7.*
-            php: 8.0
-
-          - laravel: 6.*
-            php: 8.1
-          - laravel: 6.*
-            php: 8.0
 
       # Continue running through matrix even if one combination fails
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,16 +14,25 @@ jobs:
     strategy:
       matrix:
         php: [ 8.1, 8.0, 7.4, 7.3, 7.2 ]
-        laravel: [ 9.x-dev, 8.*, 7.*, 6.* ]
+        laravel: [ 10.*, 9.*, 8.*, 7.*, 6.* ]
         os: [ ubuntu-latest, windows-latest ]
 
         # Unsupported combinations
         exclude:
-          - laravel: 9.x-dev
+          - laravel: 10.*
+            php: 8.0
+          - laravel: 10.*
             php: 7.4
-          - laravel: 9.x-dev
+          - laravel: 10.*
             php: 7.3
-          - laravel: 9.x-dev
+          - laravel: 10.*
+            php: 7.2
+
+          - laravel: 9.*
+            php: 7.4
+          - laravel: 9.*
+            php: 7.3
+          - laravel: 9.*
             php: 7.2
 
           - laravel: 8.*

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "facade/ignition-contracts": "^1.0",
-        "laravel/framework": "^6.0 || ^7.0 || ^8.0 || ^9.0"
+        "laravel/framework": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.10 || ^5.9 || ^6.4 || ^7.0",
-        "phpunit/phpunit": "^8.5 || ^9.4",
+        "orchestra/testbench": "^4.10 || ^5.9 || ^6.4 || ^7.0 || ^8.0",
+        "phpunit/phpunit": "^8.5 || ^9.4 || ^10.0",
         "php-coveralls/php-coveralls": "^2.4",
         "spatie/phpunit-snapshot-assertions": "^2.2 || ^4.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.3 || ^8.0",
         "facade/ignition-contracts": "^1.0",
-        "laravel/framework": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
+        "laravel/framework": "^8.0 || ^9.0 || ^10.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.10 || ^5.9 || ^6.4 || ^7.0 || ^8.0",
-        "phpunit/phpunit": "^8.5 || ^9.4 || ^10.0",
+        "orchestra/testbench": "^6.4 || ^7.0 || ^8.0",
+        "phpunit/phpunit": "^9.4 || ^10.0",
         "php-coveralls/php-coveralls": "^2.4",
-        "spatie/phpunit-snapshot-assertions": "^2.2 || ^4.2"
+        "spatie/phpunit-snapshot-assertions": "^4.2"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/tests/FacadePhpDocTest.php
+++ b/tests/FacadePhpDocTest.php
@@ -43,7 +43,7 @@ class FacadePhpDocTest extends TestCase
     {
         // IDE Helper (v2.4.3) doesn't rewrite class names to FQCNs, so make sure only
         // fully qualified class names and built-in types are used in the Manager class
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '/^(\\\\.*|array|object|bool|callable|int|mixed|null|string|void)$/',
             $class,
             "Must use fully qualified class names in BreadcrumbsManger PhpDoc: $line"


### PR DESCRIPTION
This PR adds support for the upcoming version Laravel 10.

PhpUnit `10.x` deprecated the method `assertRegExp` so I updated the tests to use the `assertMatchesRegularExpression` method.
Since this method is not available in old versions of PhpUnit and Laravel 6 and 7 together with PHP 7.2 are quite a while EOL I decided to just remove support for these versions.

I think we could go even further and remove support for Laravel 8 which means we could drop support for PHP 7. Feel free to update this PR to your needs.