### PR TITLE
Change the parameter type for the `parent` method

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -70,7 +70,7 @@ class Generator
      * Should be called from the closure for a page, before `push()` is called.
      *
      * @param string $name The name of the parent page.
-     * @param array ...$params The parameters to pass to the closure.
+     * @param mixed ...$params The parameters to pass to the closure.
      * @return self
      * @throws InvalidBreadcrumbException
      */


### PR DESCRIPTION
Fixed a small error message from phpstorm for the code.

Before:
![image](https://user-images.githubusercontent.com/50796878/232537940-7bfb59ea-b80d-4c17-af62-219a195763f6.png)

After:
![image](https://user-images.githubusercontent.com/50796878/232538057-0f79cc2a-2fbc-47e2-ab14-be50cb92572a.png)
