### PR TITLE
Laravel 13 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,17 +13,9 @@ jobs:
   phpunit:
     strategy:
       matrix:
-        php: [ 8.3, 8.2, 8.1 ]
-        laravel: [ 12.*, 11.*, 10.* ]
+        php: [ 8.5, 8.4, 8.3 ]
+        laravel: [ 13.*, 12.*, 11.* ]
         os: [ ubuntu-latest, windows-latest ]
-
-        # Unsupported combinations
-        exclude:
-          - laravel: 12.*
-            php: 8.1
-            
-          - laravel: 11.*
-            php: 8.1
 
       # Continue running through matrix even if one combination fails
       fail-fast: false
@@ -46,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           # Install Laravel version per matrix
-          composer require --dev "laravel/framework:${{ matrix.laravel }}" --no-interaction
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction
 
           composer install --no-interaction
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ Compatibility Chart
 
 | Laravel | Laravel Breadcrumbs |
 |---------|---------------------|
-| 12.x    | 10.x                |
-| 11.x    | 10.x                |
+| 13.x    | 11.x                |
+| 12.x    | 11.x                |
+| 11.x    | 11.x                |
 | 10.x    | 10.x                |
 | 9.x     | 9.x                 |
 | 8.x     | 9.x                 |

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrade Guide
 
+## Upgrading to 11.x from 10.x
+
+`11.x` drops support for Laravel v10 and PHP v8.1 and v8.2. There are no other breaking changes. If you're on
+PHP v8.3+ and Laravel v11+, re-run `composer require diglactic/laravel-breadcrumbs`.
+
 ## Upgrading to 10.x from 9.x
 
 `10.x` drops support for Laravel v8 and v9 to support PHPUnit v11. If you're on Laravel v10+,

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "facade/ignition-contracts": "^1.0",
-        "laravel/framework": "^10.0 || ^11.0 || ^12.0"
+        "laravel/framework": "^11.0 || ^12.0 || ^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0 || ^9.0 || ^10.0",
-        "phpunit/phpunit": "^10.5 || ^11.5",
+        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
+        "phpunit/phpunit": "^12.0",
         "spatie/phpunit-snapshot-assertions": "^5.1"
     },
     "minimum-stability": "dev",

--- a/tests/CustomManagerTest.php
+++ b/tests/CustomManagerTest.php
@@ -26,7 +26,7 @@ class CustomManagerTest extends TestCase
 
 class CustomBreadcrumbs extends Manager
 {
-    public function generate(string $name = null, ...$params): Collection
+    public function generate(?string $name = null, ...$params): Collection
     {
         return new Collection(['custom-manager']);
     }


### PR DESCRIPTION
## Summary

This PR adds Laravel 13 support and uses that update to start the package's 11.x line.

The main policy changes are:
- PHP minimum is raised to 8.3
- Laravel 10 support is dropped
- Laravel 11, 12, and 13 are supported on the new line
- the test stack is aligned with current Testbench and PHPUnit versions for those framework releases

## Why these choices

Laravel 13 requires PHP 8.3, so I chose to make that requirement explicit at the package level instead of relying on the framework constraint to enforce it indirectly.

Since this is intended as a new major line, I also dropped Laravel 10 and PHP 8.1/8.2 support rather than continue carrying end-of-life platform combinations forward. Laravel 10 is EOL, PHP 8.1 is EOL, and PHP 8.2 is already in security-only support with a much shorter remaining support window than PHP 8.3. Laravel 11 and 12 were kept because they still resolve and test cleanly on PHP 8.3+.

For the dev stack, I aligned Testbench with the supported Laravel package-testing lines and bumped PHPUnit to `^12.0`. That keeps the package on a current maintained PHPUnit line while still working across the selected Laravel/Testbench combinations without forcing PHP 8.4+.

I also updated the workflow command 
from  `composer require --dev "laravel/framework:..."` to `composer require "laravel/framework:..."`
Because `laravel/framework` is declared as a runtime dependency in this package and current Composer warns if the matrix command tries to move it into `require-dev`.

The README compatibility chart and upgrade guide were updated so the documented support policy matches the Composer constraints and CI matrix.

Finally, I included a small nullable type fix in `CustomManagerTest` because newer PHP versions emit a deprecation for the previous test method signature.

## Validation

I ran the full local matrix for:
- PHP 8.3, 8.4, and 8.5
- Laravel 11, 12, and 13

All 9 combinations passed.

The final dev stack also resolves successfully with PHPUnit 12.

One small note: PHP 8.5 + Laravel 11 still reports vendor deprecations from `orchestra/testbench-core`, but the suite passes with exit code 0.