### PR TITLE
Add Manager::rule() for registering breadcrumbs by class/method

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,6 +869,68 @@ class MyServiceProvider extends ServiceProvider
 }
 ```
 
+### Class-based breadcrumbs
+
+Instead of a closure, you can register a breadcrumb using a class and method with `Breadcrumbs::rule()`:
+
+```php
+<?php
+
+use Diglactic\Breadcrumbs\Breadcrumbs;
+
+Breadcrumbs::rule('post', PostBreadcrumb::class);
+```
+
+```php
+<?php
+
+namespace App\Breadcrumbs;
+
+use App\Models\Post;
+use Diglactic\Breadcrumbs\Generator as BreadcrumbTrail;
+
+class PostBreadcrumb
+{
+    public function __invoke(BreadcrumbTrail $trail, Post $post): void
+    {
+        $trail->parent('blog');
+        $trail->push($post->title, route('post', $post));
+    }
+}
+```
+
+The method defaults to `__invoke`, or you can specify a different one as the third argument:
+
+```php
+Breadcrumbs::rule('post', PostBreadcrumb::class, 'show');
+```
+
+Unlike `for()`, the class is **not** instantiated when you call `rule()` - it's resolved through Laravel's container
+only when that specific breadcrumb is actually generated. This means:
+
+- The class can use constructor dependency injection, the same as a controller.
+- If you're calling `rule()` from a package's service provider, none of your breadcrumb classes get instantiated on
+  requests that don't use them - only the one matching the current page (if any) is ever built.
+
+This is particularly useful if you're
+[defining breadcrumbs in another package](#defining-using-breadcrumbs-in-another-package) and want to avoid pulling in
+a closure's dependencies for every page on every request:
+
+```php
+<?php
+
+use Diglactic\Breadcrumbs\Manager;
+use Illuminate\Support\ServiceProvider;
+
+class MyServiceProvider extends ServiceProvider
+{
+    public function boot(Manager $breadcrumbs): void
+    {
+        $breadcrumbs->rule('post', PostBreadcrumb::class);
+    }
+}
+```
+
 ### Macros
 
 The breadcrumbs `Manager` class is [macroable](https://tighten.com/insights/the-magic-of-laravel-macros/), so you can

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Facade;
  * Breadcrumbs facade - allows easy access to the Manager instance.
  *
  * @method static void for(string $name, callable $callback)
+ * @method static void rule(string $name, string $class, string $method = '__invoke')
  * @method static void before(callable $callback)
  * @method static void after(callable $callback)
  * @method static bool exists(?string $name = null)

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -49,7 +49,7 @@ class Generator
     }
 
     /**
-     * Call the closure to generate breadcrumbs for a page.
+     * Call the closure (or class method, if registered via Manager::rule()) to generate breadcrumbs for a page.
      *
      * @param string $name The name of the page.
      * @param array $params The parameters to pass to the closure.
@@ -61,7 +61,15 @@ class Generator
             throw new InvalidBreadcrumbException($name);
         }
 
-        $this->callbacks[$name]($this, ...$params);
+        $callback = $this->callbacks[$name];
+
+        // Registered via Manager::rule() as [class, method] - resolve the class through the container now, rather
+        // than when it was registered, so it can use constructor dependency injection like a controller.
+        if (is_array($callback) && is_string($callback[0])) {
+            $callback = [app($callback[0]), $callback[1]];
+        }
+
+        $callback($this, ...$params);
     }
 
     /**

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -66,6 +66,28 @@ class Manager
     }
 
     /**
+     * Register a breadcrumb-generating rule using a class method instead of a closure.
+     *
+     * Unlike for(), the class is not resolved until the breadcrumb is actually generated, so it may use constructor
+     * dependency injection like a controller, without paying the cost of instantiating it for every registered page
+     * on every request.
+     *
+     * @param string $name The name of the page.
+     * @param string $class The fully-qualified class name to resolve through the container.
+     * @param string $method The method to call on the resolved instance, with the same signature as a for() callback.
+     * @return void
+     * @throws \Diglactic\Breadcrumbs\Exceptions\DuplicateBreadcrumbException If the given name has already been used.
+     */
+    public function rule(string $name, string $class, string $method = '__invoke'): void
+    {
+        if (isset($this->callbacks[$name])) {
+            throw new DuplicateBreadcrumbException($name);
+        }
+
+        $this->callbacks[$name] = [$class, $method];
+    }
+
+    /**
      * Register a closure to call before generating breadcrumbs for the current page.
      *
      * For example, this can be used to always prepend the homepage without needing to manually add it to each page.

--- a/tests/ClassMethodRuleTest.php
+++ b/tests/ClassMethodRuleTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Diglactic\Breadcrumbs\Tests;
+
+use Diglactic\Breadcrumbs\Breadcrumbs;
+use Diglactic\Breadcrumbs\Exceptions\DuplicateBreadcrumbException;
+use Diglactic\Breadcrumbs\Generator;
+use Illuminate\Http\Request;
+
+class ClassMethodRuleTest extends TestCase
+{
+    public function testInvokableClassDefaultsToInvokeMethod()
+    {
+        Breadcrumbs::rule('home', InvokableHomeBreadcrumb::class);
+
+        $html = Breadcrumbs::render('home')->toHtml();
+
+        $this->assertXmlStringEqualsXmlString('
+            <ol>
+                <li class="current">Home</li>
+            </ol>
+        ', $html);
+    }
+
+    public function testCustomMethodName()
+    {
+        Breadcrumbs::rule('about', AboutBreadcrumb::class, 'show');
+
+        $html = Breadcrumbs::render('about')->toHtml();
+
+        $this->assertXmlStringEqualsXmlString('
+            <ol>
+                <li class="current">About</li>
+            </ol>
+        ', $html);
+    }
+
+    public function testConstructorDependencyInjection()
+    {
+        Breadcrumbs::rule('injected', InjectedBreadcrumb::class);
+
+        $html = Breadcrumbs::render('injected')->toHtml();
+
+        $this->assertXmlStringEqualsXmlString('
+            <ol>
+                <li class="current">Injected OK</li>
+            </ol>
+        ', $html);
+    }
+
+    public function testParamsArePassedToTheMethod()
+    {
+        Breadcrumbs::rule('post', PostBreadcrumb::class);
+
+        $post = (object)['title' => 'Sample Post'];
+
+        $html = Breadcrumbs::render('post', $post)->toHtml();
+
+        $this->assertXmlStringEqualsXmlString('
+            <ol>
+                <li class="current">Sample Post</li>
+            </ol>
+        ', $html);
+    }
+
+    public function testDuplicateRuleThrowsException()
+    {
+        $this->expectException(DuplicateBreadcrumbException::class);
+
+        Breadcrumbs::rule('duplicate-rule', InvokableHomeBreadcrumb::class);
+        Breadcrumbs::rule('duplicate-rule', InvokableHomeBreadcrumb::class);
+    }
+
+    public function testClassIsNotInstantiatedUntilGenerated()
+    {
+        Breadcrumbs::rule('never-called', NeverInstantiatedBreadcrumb::class);
+
+        $this->assertSame(0, NeverInstantiatedBreadcrumb::$instantiations);
+    }
+}
+
+class InvokableHomeBreadcrumb
+{
+    public function __invoke(Generator $trail): void
+    {
+        $trail->push('Home');
+    }
+}
+
+class AboutBreadcrumb
+{
+    public function show(Generator $trail): void
+    {
+        $trail->push('About');
+    }
+}
+
+class InjectedBreadcrumb
+{
+    public function __construct(private Request $request)
+    {
+    }
+
+    public function __invoke(Generator $trail): void
+    {
+        $trail->push($this->request instanceof Request ? 'Injected OK' : 'Injected FAIL');
+    }
+}
+
+class PostBreadcrumb
+{
+    public function __invoke(Generator $trail, object $post): void
+    {
+        $trail->push($post->title);
+    }
+}
+
+class NeverInstantiatedBreadcrumb
+{
+    public static int $instantiations = 0;
+
+    public function __construct()
+    {
+        static::$instantiations++;
+    }
+
+    public function __invoke(Generator $trail): void
+    {
+        $trail->push('Never');
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Breadcrumbs::rule(string $name, string $class, string $method = '__invoke')` as an alternative to `for()`: register a breadcrumb by class name instead of a closure.
- The class is **not** instantiated at registration time - it's resolved through the container only when that specific breadcrumb is actually generated, so it can use constructor dependency injection like a controller, without the cost of building every registered breadcrumb class on every request.
- Particularly aimed at packages that register breadcrumbs from their own service provider's `boot()` method (see the "Defining/using breadcrumbs in another package" section of the README) - lets them avoid instantiating unused breadcrumb classes for pages the current request never touches.
- Defaults the method to `__invoke` for single-purpose, invokable breadcrumb classes.
- Documented in a new "Class-based breadcrumbs" section of the README, right after "Dependency injection".

## Test plan
- [x] New `tests/ClassMethodRuleTest.php`: default `__invoke`, custom method name, constructor DI, params passed through, `DuplicateBreadcrumbException` on repeat registration, and a test proving the class is not instantiated until the breadcrumb is actually generated.
- [x] Full existing test suite still passes (`vendor/bin/phpunit`, 73 tests / 169 assertions, via Docker `composer:2` image since Composer isn't available on this host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)